### PR TITLE
[FD-1553] lib: Fix not selecting the newest version from the versions that match the wildcard-preferred version

### DIFF
--- a/lib/bb/providers.py
+++ b/lib/bb/providers.py
@@ -145,7 +145,7 @@ def findPreferredProvider(pn, cfgData, dataCache, pkg_pn = None, item = None):
             preferred_r = None
 
         for file_set in pkg_pn:
-            for f in file_set:
+            for f in reversed(file_set):
                 pe, pv, pr = dataCache.pkg_pepvpr[f]
                 if preferredVersionMatch(pe, pv, pr, preferred_e, preferred_v, preferred_r):
                     preferred_file = f


### PR DESCRIPTION
Issue tracking:
* https://flotechnologies-jira.atlassian.net/browse/FD-1553

Explanation:

Same issue can be found here: https://patchwork.openembedded.org/patch/108877/

Quote:
> I have two recipes within a single layer:
>
>   stblinux_3.14-1.7.bb
>   stblinux_3.14-1.8.bb
>
> If PREFERRED_VERSION_stblinux is set to "3.14%", then I would expect
> the version 3.14-1.8 recipe to be selected, however 3.14-1.7 gets
> selected instead.
>
> Reversing the order of files stored in pkg_pn[pn] seems to help. Is it
> a reasonable solution?